### PR TITLE
Locally parallelize the code and log errors

### DIFF
--- a/code/cmr_connector.py
+++ b/code/cmr_connector.py
@@ -1,14 +1,25 @@
 import numpy as np
 import requests
+import time
 
 from datetime import datetime
 from lib.utils import extract_minimum_bounding_box
 
-CMR_URL = "https://cmr.earthdata.nasa.gov/search/granules.umm_json?collection_concept_id={collection_id}&temporal[]={start_datetime}&temporal[]={end_datetime}&page_size=2000"
+CMR_URL = "https://cmr.earthdata.nasa.gov/search/granules.umm_json?collection_concept_id={collection_id}&temporal[]={start_datetime}&temporal[]={end_datetime}&page_size=1000"
 QUERY = ""
 # HLS L30 = C2021957657-LPCLOUD
 # HLS S30 = C2021957295-LPCLOUD
 COLLECTIONS = ['C2021957657-LPCLOUD', 'C2021957295-LPCLOUD']
+
+import logging
+from pathlib import Path
+FOLDER = Path(__file__).parent.parent.parent / "data_transfer_files" 
+
+logging.basicConfig(filename=FOLDER / "debug.log", level=logging.DEBUG)
+handler = logging.FileHandler(FOLDER / "warning.log")
+warn_log = logging.getLogger("Warning_logger")
+warn_log.setLevel(logging.WARNING)
+warn_log.addHandler(handler)
 
 
 class CMRConnector:
@@ -28,22 +39,77 @@ class CMRConnector:
                     end_datetime=end_datetime,
                 )
             )
-            break
+            # break  # NB: This change (to comment this line, "break") is to work with products from multiple datetimes
 
     def list_downloadable_links(self):
         # pass json file to download
         # query cmr based on the dates
         downloadable_links = list()
+        count = 0
         for cmr_url in self.cmr_urls:
-            response = requests.get(cmr_url)
-            response.raise_for_status()
+            count += 1
+            print(f"list_downloadable_links() running iteration: {count}")
+            load = True
+            page_num = 1
+            while load:
+                try:
+                    retries = 10
+                    try_number = 0
+                    try:
+                        while try_number <= retries:
+                            try:
+                                response = requests.get(f"{cmr_url}&page_num={page_num}", timeout=200+100*try_number)
+                                # if response.status_code == 404:
+                                #     print(f"404 Status code, trying pagesize 1000...")
+                                #     logging.error(f"404 Status code, trying pagesize 1000...")
+                                #     warn_log.error(f"Status code == 404 for link: {cmr_url}&page_num={page_num}")
+                                #     if cmr_url[-4:] == "1000":
+                                #         try_number += 1
+                                #     cmr_url = cmr_url[:-4] + "1000"  # setpage size to 1000
+                                #     continue
+                                break
+                            except requests.exceptions.Timeout as e:
+                                print(f"Timeout received on try number (zero-indexed): {try_number}, with timeout time set to {200+100*try_number}s")
+                                logging.info(f"Timeout received on try number (zero-indexed): {try_number}, with timeout time set to {200+100*try_number}s")
+                            except requests.exceptions.HTTPError as e:
+                                print(f"HTTP Error received on try number (zero-indexed): {try_number}: {e}")
+                                logging.error(f"HTTP Error received on try number (zero-indexed): {try_number}: {e}")
+                                time.sleep(min(2**10, 2**try_number+10))
+                                if response.status_code == 404 or try_number > retries//2:
+                                    if response.status_code == 404:
+                                        print(f"Status code == 404 for link: {cmr_url}&page_num={page_num}")
+                                        warn_log.error(f"Status code == 404 for link: {cmr_url}&page_num={page_num}")
+                                    cmr_url = cmr_url[:-4] + "1000"  # setpage size to 1000
+                            try_number += 1
+                            if try_number > retries:
+                                logging.warning(f"Max retries reached for cmr_url: {cmr_url}&page_num={page_num}")
+                                continue
 
-            for item in response.json()['items']:
-                for url in item['umm']['RelatedUrls']:
-                    if (
-                        ('s3:' not in url['URL'])
-                        and ('.tif' in url['URL'])
-                        # and ('mask' not in url['URL'])
-                    ):
-                        downloadable_links.append(url['URL'])
+                        response.raise_for_status()
+                    except Exception as e:
+                        print(e)
+                        warn_log.error(e)
+                        print(f"Error on url: {cmr_url}&page_num={page_num}")
+                        warn_log.error(f"Error on url: {cmr_url}&page_num={page_num}")
+                        load = False
+                        continue
+
+                    if not (response.json()['items']):
+                        load = False
+                        continue
+                    len_dl_links = len(downloadable_links)
+                    for item in response.json()['items']:
+                        for url in item['umm']['RelatedUrls']:
+                            if (
+                                ('s3:' not in url['URL'])
+                                and ('.tif' in url['URL'])
+                                # and ('mask' not in url['URL'])
+                            ):
+                                downloadable_links.append(url['URL'])
+                    page_num += 1
+                    if len(downloadable_links) == len_dl_links or page_num % 10 == 0:
+                        print(f"Current page num: {page_num}")
+                except Exception as e:
+                    warn_log.error(f"Exception received on 'try' statement from within 'while load': {e}")
+                    load = False
         return downloadable_links

--- a/code/downloader.py
+++ b/code/downloader.py
@@ -7,6 +7,7 @@ from lib.utils import mkdir
 from lib.session_with_header_redirection import SessionWithHeaderRedirection
 from rasterio.warp import calculate_default_transform, reproject, Resampling
 
+from cmr_connector import warn_log
 
 class Downloader:
     def __init__(self, username, password):
@@ -49,5 +50,6 @@ class Downloader:
                             )
                         except Exception as e:
                             print(f"Couldn't download link: {link}, {e}")
+                            warn_log.error(f"Couldn't download link: {link}, {e}")
                             continue
         return downloaded_scenes

--- a/code/downloader_from_code_folder.py
+++ b/code/downloader_from_code_folder.py
@@ -1,0 +1,51 @@
+# Begin by activating a venv containing rasterio and other required packages.
+# This can be achieved for now with "source <REL>/hls_transfer/bin/activate" 
+# where <REL> is some relative path to the given folder. Current full path is:
+# /p/largedata2/sdlrsd/data_transfer_test/hls_transfer/bin/activate
+
+# This code should be copied over to and run from the 
+# ./earthdata-data-downloader/code/ directory.
+
+# It is advisable that this script be run in a separate screen (see "man screen") as this is a parallelized script that might take some time to complete.
+
+# from pathlib import Path
+# print(f"CWD: {Path.cwd()}")
+from data_preparer import DataPreparer
+from cmr_connector import COLLECTIONS
+import getpass
+import multiprocessing
+import os
+
+# desired_path = input("[presumably Relative or Absolute]Path to where we want to download the data: ")
+desired_path = "../../data_transfer_files/downloaded_data/"
+username = input("Username: ")
+password = getpass.getpass()
+num_processes = 1
+
+def get_path(i:int):
+    return f"../../data_transfer_files/us_hls_tiles_purged_total{num_processes}_{i}.json"
+    
+def worker_function(i):
+    print(f"Worker {i} has been started...")
+    for collection_id in COLLECTIONS:
+        dp = DataPreparer(collection_id, username, password, desired_path, get_path(i), "train_indices")
+        # print(f"{collection_id}, self.tiles_info: {dp.tiles_info}")
+        # continue
+        dp.download_and_prepare_clips()
+
+# for collection_id in COLLECTIONS:
+#     dp = DataPreparer(collection_id, username, password, desired_path, "../../data_transfer_files/us_hls_tiles_purged_t3_s3_p00.json", "train_indices")
+#     dp.download_and_prepare_clips()
+
+
+if __name__ == "__main__":
+    # num_processes = 8
+    processes = []
+    print("Number of usable cores: ", len(os.sched_getaffinity(0)))
+    for i in range(num_processes):
+        p = multiprocessing.Process(target=worker_function, args=(i,))
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()


### PR DESCRIPTION
An edit to the `hls-pretraining_downloader` branch (that is introduced in a new branch `hls-pretraining_downloader_parallel`) in an effort to both handle some errors and parallelize the download somewhat. Conceptually this might/should be rebased onto the latest commit in `hls-pretraining_downloader` branch.